### PR TITLE
enabled devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+#BUILDER
+FROM node:19-alpine as builder
+
+#Make the builder directory
+WORKDIR /website_fosscu
+
+#COPY build source from project
+COPY package*.json .
+COPY yarn.lock .
+
+#Copy all files into container
+COPY . .
+
+#Installing all dependencies
+RUN yarn install
+
+
+#MAIN
+FROM node:19-alpine as main
+
+#Make main app directory
+WORKDIR /app
+
+#Copy all from builder stage
+COPY --from=builder /website_fosscu/.  ./
+
+# Run the production build
+RUN yarn build
+
+# Start the server
+CMD ["yarn", "start"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "website-fosscu",
+    "dockerFile": "Dockerfile",
+    "context": "..", 
+    "remoteUser": "node",
+    "forwardPorts": [8080], 
+    "postCreateCommand": "yarn", 
+    "shutdownAction": "none",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash",
+                "editor.formatOnSave": true, 
+                "eslint.alwaysShowStatus": true 
+            },
+            "extensions": [
+                "dbaeumer.vscode-eslint", 
+                "esbenp.prettier-vscode", 
+                "ms-azuretools.vscode-docker" 
+            ]
+        }
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,8 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env
+  },
+  server: {
+    port: 8080, // Set the desired port here
   }
 });


### PR DESCRIPTION
## [Feature] Enabling DevContainers for Development 

Fixes #199 

## STEPS 
1. Dockerfile: Given there. put it inside .devcontainer
2. Port Forwarding: The port 8000 is forwarded for Vite 
3. VS Code Extensions:
eslint for code linting.
prettier for code formatting.
gitlens for Git integration.
typescript extension (since you’re using Vite, this is useful for TypeScript support).
4. Post Create Command: yarn to install your dependencies after the container is built.

## Major Steps: 
1. Make  sure you have a Dockerfile inside your .devcontainer folder.
2. Run the command Dev Containers: Reopen in Container in VS Code to initialize the DevContainer setup.
