### PR TITLE
[FIXES] #363

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -33,7 +33,7 @@ const Navbar = () => {
     <>
       <div className="flex justify-between items-center h-24 max-w-[1240px] mx-auto  px-4  text-white">
         <RiOpenSourceFill className="flex-shrink-0" size={31} color="green" />
-        <h1 className="w-full text-3xl font-bold text-[#0DFF1C] m-4">
+        <h1 className="w-full text-3xl font-bold text-[#0DFF1C] p-4">
           {" "}
           FOSSCU
         </h1>


### PR DESCRIPTION

## Fix: Navbar Title Overflow Issue in Mobile View



## Description

Resolved the issue of the navbar title overflowing in mobile view by changing the m-4 to p-4

## Related Issues
This PR fixes issue #363 


## How to Test
Open the [FOSSCU website](https://fosscu.org/) in your preferred browser.
Switch to mobile view:
On a desktop browser, open the developer tools (e.g., by pressing F12 or Ctrl+Shift+I).
Click on the responsive design mode or device toggle icon to simulate a mobile device.
Alternatively, test directly on a mobile device.
Open the navbar:
Locate and click on the hamburger menu (☰) or equivalent icon to expand the navigation bar.
Look for the "FOSSCU" heading in the navbar.
Ensure it is visible, correctly aligned, and functioning as expected.

## Screenshots (if applicable)

![Screenshot 2024-11-30 192537](https://github.com/user-attachments/assets/6249a8a2-4476-436a-9fe6-3c898b7a5354)



