### PR TITLE
FIXED #386

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -15,8 +15,8 @@ const projectItems = [
     url: "https://paste.fosscu.org"
   },
   {
-    title: "Linkliberte",
-    url: "https://github.com/foss-community/linkliberte"
+    title: "LinkLiberate",
+    url: "https://github.com/foss-community/LinkLiberate"
   },
   {
     title: "FOSSConf",


### PR DESCRIPTION
Fixes
Fixes https://github.com/FOSS-Community/fosscu.org/issues/386 by @rishav76dev
Description
This pull request resolves an issue where the "Linkliberate" link in the home page fails to redirect to the expected page .

##Checklist
 My pull request targets the default branch of the repository (main or master).
 My commit messages follow best practices.
 My code follows the established code style of the repository.
 I tried running the project locally and verified that there are no
visible errors.
